### PR TITLE
Test in both python 3.10 and 3.11 and install dev group before tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,15 @@ defaults:
 env:
   LANG: en_US.utf-8
   LC_ALL: en_US.utf-8
-  PYTHON_VERSION: '3.10'
 
 jobs:
   run-tests:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: ["ubuntu-22.04"]
+        python: ["3.10", "3.11"]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - run: echo "🔎 The job was triggered from repository ${{ github.repository }} and branch ${{ github.ref }}"
@@ -61,6 +65,5 @@ jobs:
       #----------------------------------------------
       - name: Install library and run tests
         run: |
-          pip install pytest
-          poetry install --no-interaction
+          poetry install --no-interaction --with dev
           poetry run pytest

--- a/actions-all-repositories/run-tests.yml
+++ b/actions-all-repositories/run-tests.yml
@@ -14,7 +14,8 @@ on:
       - reopened
     paths:
       - '**.py'
-workflow_dispatch:
+      -
+  workflow_dispatch:
 
 defaults:
   run:
@@ -23,7 +24,6 @@ defaults:
 env:
   LANG: en_US.utf-8
   LC_ALL: en_US.utf-8
-  PYTHON_VERSION: '3.10'
   PROJECT_NAME: volttron-core
 
 jobs:


### PR DESCRIPTION
Updated run-test workflow to
  Test in both python 3.10 and 3.11 and 
  install dev group before tests

update individual repo's run-test to use the github tool run-tests.yml