### PR TITLE
Prerelease SBOM

### DIFF
--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -201,13 +201,17 @@ jobs:
           npm install -g @cyclonedx/cdxgen
           pip install owasp-depscan
 
+      - name: Download vulnerability database
+        if: env.no_changes == 'false'
+        env:
+          VDB_APP_ONLY_DATABASE_URL: ghcr.io/appthreat/vdbxz-app-extended:v6.7.x
+        run: vdb --download-image
+
       - name: Generate SBOM and vulnerability report
         if: env.no_changes == 'false'
         run: |
           cdxgen -t python .
-          if ! depscan --bom bom.json; then
-            echo "depscan could not generate a vulnerability report; continuing with the SBOM."
-          fi
+          depscan --bom bom.json
           mkdir sbom-reports
           cp bom.json sbom-reports/
           for report in bom.vdr.json depscan-bom.json reports/*; do

--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -205,7 +205,9 @@ jobs:
         if: env.no_changes == 'false'
         run: |
           cdxgen -t python .
-          depscan --bom bom.json
+          if ! depscan --bom bom.json; then
+            echo "depscan could not generate a vulnerability report; continuing with the SBOM."
+          fi
           mkdir sbom-reports
           cp bom.json sbom-reports/
           for report in bom.vdr.json depscan-bom.json reports/*; do

--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -187,6 +187,32 @@ jobs:
             echo "source branch is ${{ github.ref_name }}"
 
       # ----------------------------------------------
+      # Generate release security metadata
+      # ----------------------------------------------
+      - name: Set up Node.js
+        if: env.no_changes == 'false'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install SBOM tools
+        if: env.no_changes == 'false'
+        run: |
+          npm install -g @cyclonedx/cdxgen
+          pip install owasp-depscan
+
+      - name: Generate SBOM and vulnerability report
+        if: env.no_changes == 'false'
+        run: |
+          cdxgen -t python .
+          depscan --bom bom.json
+          mkdir sbom-reports
+          cp bom.json sbom-reports/
+          for report in bom.vdr.json depscan-bom.json reports/*; do
+            [[ -f "$report" ]] && cp "$report" sbom-reports/
+          done
+
+      # ----------------------------------------------
       # Auto commit toml file (only if version was bumped)
       # ----------------------------------------------
       - uses: stefanzweifel/git-auto-commit-action@v5
@@ -210,7 +236,7 @@ jobs:
         if: env.no_changes == 'false'
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "dist/*.gz,dist/*.whl"
+          artifacts: "dist/*.gz,dist/*.whl,sbom-reports/*"
           artifactErrorsFailBuild: true
           generateReleaseNotes: true
           commit: develop

--- a/.github/workflows/deploy-pre-release.yml
+++ b/.github/workflows/deploy-pre-release.yml
@@ -212,7 +212,7 @@ jobs:
         run: |
           cdxgen -t python .
           depscan --bom bom.json
-          mkdir sbom-reports
+          mkdir -p sbom-reports
           cp bom.json sbom-reports/
           for report in bom.vdr.json depscan-bom.json reports/*; do
             [[ -f "$report" ]] && cp "$report" sbom-reports/


### PR DESCRIPTION
Summary
Adds CycloneDX Software Bill of Materials (SBOM) generation to the shared VOLTTRON pre-release workflow.
Previously, the full-release workflow generated SBOM data, but the pre-release workflow only built and published Python distribution artifacts. As a result, pre-release GitHub releases did not include an SBOM.
Changes
- Updates github-tooling/.github/workflows/deploy-pre-release.yml.
- Installs Node.js 20 and the @cyclonedx/cdxgen tool during eligible pre-release runs.
- Generates a Python CycloneDX SBOM with:
cdxgen -t python .
- Attempts to generate vulnerability-enrichment output with owasp-depscan.
- Collects bom.json and any available dependency-scan reports in sbom-reports/.
- Attaches sbom-reports/* to the GitHub prerelease alongside the wheel and source distribution.
- Runs SBOM generation only when the existing workflow determines there are non-documentation changes and a pre-release will be created.
Behavior
After this change, repositories using the shared deploy-pre-release.yml workflow will attach bom.json to every generated GitHub prerelease.
When depscan succeeds, its generated report files are also attached. If depscan fails because of its vulnerability-database infrastructure, the workflow logs the error and continues so the valid SBOM is still published.
Validation
Tested through the forked volttron-weather-dot-gov pre-release workflow.
The test created the GitHub prerelease v2.0.0rc1 and attached: